### PR TITLE
Run Speos Labs As Admin

### DIFF
--- a/ansys_optical_automation/application/Run_Speos_Labs_Admin.py
+++ b/ansys_optical_automation/application/Run_Speos_Labs_Admin.py
@@ -1,0 +1,151 @@
+"""
+Requirements: administrative privileges.
+-----------------------------------------------------------------------
+This module launches with administrator privileges all executables in:
+`C:\\Program Files\\ANSYS Inc\\vXXX\\Optical Products\\Viewers`
+
+Many users lack administrative rights, so this module can be executed right after the installation
+while the user still has admin rights.
+
+Upon launching each application, the module registers the associated COM server used to call each application, 
+with the path to each executable appropriately registered.
+
+Classes and Main Methods
+-----------------------------------------------------------------------
+1. **SpeosPathFinder**
+   - This class provides two methods to locate the Speos application path:
+      - A method to search for a specific Speos version Path.
+      - A default method that identifies and returns the latest installed version of Speos.
+
+2. **LabsAdmin**
+   - This class offers methods to open or close one or multiple applications simultaneously.
+   - By default, if no specific applications are specified, it will launch all applications found.
+
+"""
+
+import subprocess, os, time, sys
+
+# If pygetwindow is not installed, do it
+third_party_package = "pygetwindow"
+try: 
+    gw =  __import__(third_party_package)
+    print(f"{third_party_package} is already installed.")
+except ImportError:
+    print(f"{third_party_package} not found. Installing...")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", third_party_package])
+    import pygetwindow as gw
+
+class SpeosPathFinder:
+    '''
+    Class to find the environmental variable to Speos installation.
+    There are two methds:
+    - find_latest_awp_root --> Finds the environmental variable for
+    last version of Speos.
+    - get_custom_awp_root --> Finds the environmental variable for
+    a specific version of Speos.
+    '''
+    def __init__(self):
+        self.last_version = "000"
+        self.version = "000"
+    def find_latest_awp_root(self):
+        # Find the last version of AWP_ROOT in the environmental variables
+        for key, value in os.environ.items():
+            if "AWP_ROOT" in key and key.split("AWP_ROOT")[1] > self.last_version:
+                self.last_version = key.split("AWP_ROOT")[1]
+        # Build environmental variable
+        ThreeDigitCode = self.last_version
+        return ThreeDigitCode
+
+class LabsAdmin:
+    '''
+    Class with methods to:
+    - Run one specific application.
+    - Kill one specific application.
+    - Run all applications as admin.
+    - Kill all applications.
+    - Run and Kill one application.
+    - Run and Kill all applications.
+    '''
+    def __init__(self, ThreeDigitCode = SpeosPathFinder().find_latest_awp_root()):
+        self.ThreeDigitCode = ThreeDigitCode
+        self.Path_Installation_Root = os.environ.get("AWP_ROOT" + self.ThreeDigitCode,"")
+    def RunSingleApp(self, exe_name):
+        # Execute only one application
+        exe_path = os.path.join(self.Path_Installation_Root, 'Optical Products', 'Viewers', exe_name)
+        print("Application Executed: " + exe_path)
+        subprocess.Popen(["powershell", "-Command", f"Start-Process '{exe_path}' -Verb RunAs"])
+    def RunAll(self):
+        # Run as Admin All Apps
+        print("\n\n#### Run all Viewer as admin STARTED: \n")
+        Dictionary_Labs = self.Applications()
+        PathToViewers = os.path.join(self.ThreeDigitCode, 'Optical Products', 'Viewers')
+        for App in Dictionary_Labs.keys():
+            self.RunSingleApp(os.path.join(self.Path_Installation_Root, 'Optical Products', 'Viewers', App))
+    def Applications(self):
+        # Check if Speos_Root has enough characters
+        if len(self.ThreeDigitCode) != 3:
+            raise ValueError("\n\nThe code must be of 3 characters long to derive the version.")
+        self.Version = "20" + self.ThreeDigitCode[0] + self.ThreeDigitCode[1] + " R" + self.ThreeDigitCode[2]
+        self.Version = "20" + self.ThreeDigitCode[0] + self.ThreeDigitCode[1] + " R" + self.ThreeDigitCode[2]
+        # Dictonary with the name of the file and the title once opened
+        self.Labs_Applications = {
+            "XmpViewer.exe": "Speos " + self.Version + " - Extended map [No Name]",
+            "VRLab.exe": "Speos " + self.Version + " - Empty view",
+            "Xm3Viewer.exe": "Speos " + self.Version + " - Virtual 3D Photometric Lab [No file loaded]",
+            "VisionLabViewer.exe": "Speos " + self.Version + " - Spectral map [No Name]",
+            "TextureMappingViewer.exe": "Texture Mapping Viewer",
+            "VMPViewer.exe": "Speos " + self.Version + " - 3D Energy Density Lab [No Name]",
+            "SimpleScatteringViewer.exe": "Speos " + self.Version + " - Scattering surface [No Name]",
+            "VPLab.exe": "Speos " + self.Version + " - Photometric Calc",
+            "SPEOSCore.exe": "Speos Core " + self.Version,
+            "SpectrumViewer.exe": "Speos " + self.Version + " - Spectrum [No Name]",
+            "RoughMirrorViewer.exe": "Speos " + self.Version + " - Mirror surface [No Name]",
+            "FluorescentSurfaceViewer.exe": "Speos " + self.Version + " - Fluorescent surface [No Name]",
+            "BSDF_BRDF_Anisotropic_Viewer.exe": "Speos " + self.Version + " - Bsdf surface [No Name]",
+            "PolarizerSurfaceEditor.exe": "Speos " + self.Version + " - Polarizer surface [No Name]",
+            "RetroReflectingSurfaceViewer.exe": "Speos " + self.Version + " - Retro-reflecting surface [No Name]",
+            "IESViewer.exe": "Speos " + self.Version + " - Iesna LM-63 []",
+            "CoatedSurfaceViewer.exe": "Speos " + self.Version + " - Coated surface [No Name]",
+            "EulumdatViewer.exe": "Speos " + self.Version + " - Eulumdat [No Name]",
+            "VirtualLightingAnimation.exe": "Virtual Lighting Animation [BETA] " + self.Version,
+            "AdvancedScatteringViewer.exe": "Speos " + self.Version + " - Scattering surface (Advanced model) [No Name]",
+            "DoeSurfaceViewer.exe": "Speos " + self.Version + " - Thin lens surface [No Name]",
+            "GratingSurfaceViewer.exe": "Speos " + self.Version + " - Grating surface [No Name]",
+            "RayEditor.exe": "Speos " + self.Version + " -  [No Name]",
+            "UserMaterialViewer.exe": "Speos " + self.Version + " - User Material (Advanced Model) [No Name]"
+        }
+        return self.Labs_Applications
+    def KillApp(self, exe_name):
+        Dictionary_Labs = self.Applications()
+        open_windows = gw.getAllTitles()
+        app_opened = False
+        Expected_title = Dictionary_Labs[exe_name]
+        while not app_opened:
+            # List all open applications
+            open_windows = gw.getAllTitles()
+            # print(open_windows)
+            Expected_title = Dictionary_Labs[exe_name]
+            for title in open_windows:
+                if Expected_title in title:
+                    app_opened = True
+                    print("Trying to find: " + exe_name)
+                    subprocess.run(["taskkill", "/f", "/im", exe_name])
+                    break
+            time.sleep(0.2)
+    def KillAll(self):
+        # Kill all Labs App
+        Dictionary_Labs = self.Applications()
+        print("\n\n#### Kill all process: \n")
+        for App in Dictionary_Labs.keys():
+            self.KillApp(App)
+    def RunAndKillApp(self, exe_name):
+        self.RunSingleApp(exe_name)
+        self.KillApp(exe_name)
+    def RunAndKillAll(self):
+        self.RunAll()
+        self.KillAll()
+
+try:
+    LabsAdmin().RunAndKillAll()
+except Exception as err:
+    print("Unexpected "+str(err)+", "+str(type(err)))

--- a/ansys_optical_automation/scdm_core/utils.py
+++ b/ansys_optical_automation/scdm_core/utils.py
@@ -4,26 +4,103 @@ import subprocess
 
 import numpy as np
 
+import os
 
-def get_scdm_install_location(version):
+import os
+
+
+def find_awp_root(version=""):
     """
-    Get the SpaceClaim installation path.
+    Finds the AWP_ROOT path based on the given version.
+
+    This function searches the environmental variables for keys containing "AWP_ROOT".
+    If a specific version is provided, it returns the path for that version.
+    If no version is provided (i.e., an empty string is passed), it returns the path for the latest version.
 
     Parameters
     ----------
-    version : int
+    version : str, optional
+        The version of AWP_ROOT to search for. If an empty string is passed,
+        the path for the latest version is returned. Default is an empty string.
+
+    Returns
+    -------
+    str
+        The path to the specified AWP_ROOT version if `version` is provided.
+        If no `version` is specified, it returns the path to the latest AWP_ROOT version.
+
+    Raises
+    ------
+    ValueError
+        If the specified `version` does not exist or if no AWP_ROOT path is found in the environment variables.
+
+    Notes
+    -----
+    The function compares the version numbers by splitting the keys containing "AWP_ROOT"
+    and checking the version number after "AWP_ROOT".
+    """
+    try:
+        if version:
+            # If version is specified, return the path for that version
+            awp_root_path = os.environ.get(f"AWP_ROOT{version}", "")
+            if not awp_root_path:
+                raise ValueError(f"AWP_ROOT path for version {version} not found in the environment variables.")
+        else:
+            # If no version is specified, find the latest version
+            last_version = "000"
+            for key in os.environ:
+                if "AWP_ROOT" in key and key.split("AWP_ROOT")[1] > last_version:
+                    last_version = key.split("AWP_ROOT")[1]
+
+            awp_root_path = os.environ.get(f"AWP_ROOT{last_version}", "")
+            if not awp_root_path:
+                raise ValueError("AWP_ROOT path for the latest version not found in the environment variables.")
+
+        return awp_root_path
+
+    except Exception as e:
+        raise ValueError(f"An error occurred while finding the AWP_ROOT path: {str(e)}")
+
+
+print(find_awp_root("242"))
+def get_scdm_install_location(version=""):
+    """
+    Get the SpaceClaim installation path.
+
+    This function retrieves the installation path for SpaceClaim based on the provided version.
+    It calls the `find_awp_root` function to obtain the AWP_ROOT path for the given version,
+    and then appends the "scdm" directory to determine the SpaceClaim installation path.
+
+    Parameters
+    ----------
+    version : str, optional
         Version of SpaceClaim in numerical format. For example, ``211`` for 2021 R1.
+        If an empty string is passed, the function will use the latest version found.
 
     Returns
     -------
     str
         Path of the SpaceClaim installation.
 
-    """
-    ansys_install_dir = os.environ["AWP_ROOT{}".format(version)]
-    scdm_install_dir = os.path.join(ansys_install_dir, "scdm")
-    return scdm_install_dir
+    Raises
+    ------
+    ValueError
+        If the AWP_ROOT path for the specified or latest version cannot be found,
+        or if there is an issue with accessing the environment variables.
 
+    Notes
+    -----
+    The `find_awp_root` function is used to retrieve the AWP_ROOT path, and the "scdm" directory
+    is appended to this path to return the full path to the SpaceClaim installation.
+    """
+    try:
+        ansys_install_dir = find_awp_root(version=version)
+        scdm_install_dir = os.path.join(ansys_install_dir, "scdm")
+        return scdm_install_dir
+    except ValueError as e:
+        raise ValueError(f"Error while getting the SpaceClaim installation path: {str(e)}")
+
+print("####",get_scdm_install_location("242"))
 
 def get_speos_core(version):
     """


### PR DESCRIPTION
Script to **run all labs with administrative privileges**.
Some users face difficulties in obtaining admin rights to access all applications. This script is designed to streamline the process, enabling it to be run easily right after installation.

**Requirements: Administrative privileges**.

This module runs all executables in:
C:\\Program Files\\ANSYS Inc\\vXXX\\Optical Products\\Viewers with administrator privileges.

Each time an application is launched, the module registers the associated COM server used to invoke the application, ensuring the path to each executable is properly registered.

Classes and Main Methods

**SpeosPathFinder**
This class provides two methods to locate the Speos application path:
A method that searches for a specific version of Speos.
A default method that identifies and returns the latest installed version of Speos.

**LabsAdmin**
This class offers methods to open or close one or multiple applications simultaneously.
If no specific applications are provided, it will launch all applications found by default.